### PR TITLE
[fix/8] 채팅방 참가시 인원에 대한 예외처리 추가

### DIFF
--- a/src/main/java/server/cubeTalk/chat/model/entity/Participant.java
+++ b/src/main/java/server/cubeTalk/chat/model/entity/Participant.java
@@ -2,8 +2,10 @@ package server.cubeTalk.chat.model.entity;
 
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
+@Getter
 public class Participant {
     private String memberId;
     private String role;


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- 채팅방 참가시 인원에 대한 예외처리
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- chatRoomService : participantsValidate 메서드 추가
- 최대인원 검증 : 참가시 participants의 object 수를 계산 - maxparticipatns + 4 랑비교 
- 각 포지션 인원 검증 : 참가시 participants의 filter -> 각 role의 숫자 계산 : 찬성, 반대 가 (최대사용자수) /2 가 넘으면 예외처리 
 관전의 수는 4명을 넘으면 예외처리 

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
