### PR TITLE
[feat/36] 채팅 설정 patch API 구현 ver 1.0

### DIFF
--- a/src/main/java/server/cubeTalk/chat/controller/ChatController.java
+++ b/src/main/java/server/cubeTalk/chat/controller/ChatController.java
@@ -174,4 +174,23 @@ public class ChatController {
         return new ResponseEntity<>(CommonResponseDto.success(responseDto), HttpStatus.OK);
     }
 
+    @PatchMapping("/{id}/settings")
+    @Operation(summary = "채팅방 설정 변경하는 API", description = "채팅 설정 변경을 요청하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "success",
+                    content = {@Content(schema = @Schema(implementation = CommonResponseDto.CommonResponseSuccessDto.class))}),
+            @ApiResponse(responseCode = "400", description = "fail",
+                    content = {@Content(schema = @Schema(implementation = CommonResponseDto.CommonResponseErrorDto.class))})
+    })
+    public ResponseEntity<CommonResponseDto.CommonResponseSuccessDto> changeChatRoomSettings(
+            @PathVariable("id")
+            @Pattern(regexp = "^[a-fA-F0-9]{24}$",
+                    message = "Invalid UUID format") String id,
+            @Valid @RequestBody ChatRoomChangeSettingsRequestDto chatRoomChangeSettingsRequestDto
+    ) {
+        String message = chatRoomService.changeChatRoomSettings(id, chatRoomChangeSettingsRequestDto);
+
+        return new ResponseEntity<>(CommonResponseDto.CommonResponseSuccessDto.success(200, message), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/server/cubeTalk/chat/model/dto/ChatRoomChangeSettingsRequestDto.java
+++ b/src/main/java/server/cubeTalk/chat/model/dto/ChatRoomChangeSettingsRequestDto.java
@@ -1,0 +1,17 @@
+package server.cubeTalk.chat.model.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@NoArgsConstructor
+@Getter
+public class ChatRoomChangeSettingsRequestDto {
+    private String ownerId;
+    private int maxParticipants; //'찬반'이면 짝수 및 6명이상인지 검증함, Not empty
+    private Optional<Double> chatDuration = Optional.empty(); //"찬반"이면 해당 필드 포함 안 하기
+    private Optional<DebateSettingsRequest> debateSettings = Optional.empty();  //-> "자유"면 해당 필드 포함 안 하기
+}

--- a/src/main/java/server/cubeTalk/chat/model/dto/DebateSettingsRequest.java
+++ b/src/main/java/server/cubeTalk/chat/model/dto/DebateSettingsRequest.java
@@ -3,6 +3,7 @@ package server.cubeTalk.chat.model.dto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import server.cubeTalk.chat.model.entity.DebateSettings;
 
 @Getter
 @NoArgsConstructor
@@ -13,5 +14,18 @@ public class DebateSettingsRequest {
     private int positiveQuestioning;
     private int positiveRebuttal;
     private int negativeRebuttal;
+
+    // DTO를 엔티티로 변환하는 메서드
+    public DebateSettings toEntity() {
+        return DebateSettings.builder()
+                .positiveEntry(this.positiveEntry)
+                .negativeEntry(this.negativeEntry)
+                .positiveRebuttal(this.positiveRebuttal)
+                .negativeRebuttal(this.negativeRebuttal)
+                .positiveQuestioning(this.positiveQuestioning)
+                .negativeQuestioning(this.negativeQuestioning)
+                .votingTime(0.5)
+                .build();
+    }
 
 }


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
채팅 설정 patch API 구현 ver 1.0

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
유효성 검증
- 찬반'이면 짝수 및 6명이상인지 검증함
- 자유면 chatDuration 필드 필수
- 찬반이면 debateSettings 필수
chatRoom update
### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  네
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
