### PR TITLE
[Fix/55] 구독 세션 유지 설정 및 채팅 메시지 검증 수정

### DIFF
--- a/src/main/java/server/cubeTalk/chat/handler/WebSocketChatEventListener.java
+++ b/src/main/java/server/cubeTalk/chat/handler/WebSocketChatEventListener.java
@@ -60,27 +60,30 @@ public class WebSocketChatEventListener {
                 ChatRoom chatRoom = chatRoomRepository.findById(id)
                         .orElseThrow(()-> new IllegalArgumentException("해댕 채팅방이 존재하지않습니다."));
                 log.info("채팅 구독");
-                subscriptionManager.addSubscription(sessionId, channelId, nickName);
-                /* 메인 채팅방에 입장하는 경우 */
-                if (chatRoom.getChannelId().equals(channelId)) {
-                    String message = nickName + "님이 입장하셨습니다.";
-                    ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto("ENTER",message);
-                    String jsonStringEnterMessage = new ObjectMapper().writeValueAsString(chatMessage);
-                    messageSendingOperations.convertAndSend(destination, jsonStringEnterMessage);
-                }
-                /* 서브 채팅방에 입장하는 경우 */
-                else  {
-                    chatRoom.getSubChatRooms().stream()
-                            .filter(subChatRoom -> subChatRoom.getSubChannelId().equals(channelId))
-                            .findFirst()
-                            .map(SubChatRoom::getSubChannelId)
-                            .orElseThrow(() -> new IllegalArgumentException("서브 채팅방이 존재하지 않습니다."));
+                if (!subscriptionManager.isSubscribed(sessionId,channelId)) {
                     subscriptionManager.addSubscription(sessionId, channelId, nickName);
-                    String message = nickName + "님이 입장하셨습니다.";
-                    ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto("ENTER",message);
-                    String jsonStringEnterMessage = new ObjectMapper().writeValueAsString(chatMessage);
-                    messageSendingOperations.convertAndSend(destination, jsonStringEnterMessage);
+                    /* 메인 채팅방에 입장하는 경우 */
+                    if (chatRoom.getChannelId().equals(channelId)) {
+                        String message = nickName + "님이 입장하셨습니다.";
+                        ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto("ENTER", message);
+                        String jsonStringEnterMessage = new ObjectMapper().writeValueAsString(chatMessage);
+                        messageSendingOperations.convertAndSend(destination, jsonStringEnterMessage);
+                    }
+                    /* 서브 채팅방에 입장하는 경우 */
+                    else {
+                        chatRoom.getSubChatRooms().stream()
+                                .filter(subChatRoom -> subChatRoom.getSubChannelId().equals(channelId))
+                                .findFirst()
+                                .map(SubChatRoom::getSubChannelId)
+                                .orElseThrow(() -> new IllegalArgumentException("서브 채팅방이 존재하지 않습니다."));
+                        subscriptionManager.addSubscription(sessionId, channelId, nickName);
+                        String message = nickName + "님이 입장하셨습니다.";
+                        ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto("ENTER", message);
+                        String jsonStringEnterMessage = new ObjectMapper().writeValueAsString(chatMessage);
+                        messageSendingOperations.convertAndSend(destination, jsonStringEnterMessage);
+                    }
                 }
+
             }
             else {
                 /* 채팅방 목적지 외 처리 */

--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -668,6 +668,9 @@ public class ChatRoomService {
 //            validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
 //        }
 //        validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
+        if (!chatRoom.getChannelId().equals(channelId)) {
+            validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
+        }
 
         List<Participant> participants = chatRoom.getParticipants();
         if (participants == null || participants.isEmpty()) {

--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -31,6 +31,7 @@ public class ChatRoomService {
     private final MessageRepository messageRepository;
     private final WebSocketService webSocketService;
     private final SubscriptionManager subscriptionManager;
+    private boolean isRollBack = false;
 
     /* 채팅방 생성 */
     public ChatRoomCreateResponseDto createChatRoom(ChatRoomCreateRequestDto requestDto) {
@@ -88,6 +89,9 @@ public class ChatRoomService {
 
     /* 채팅방 참가 */
     public ChatRoomJoinResponseDto joinChatRoom(String id, ChatRoomJoinRequestDto chatRoomJoinRequestDto) {
+        if (isRollBack) {
+            throw new IllegalArgumentException("롤백처리 중이기 때문에 지금은 참가할 수 없습니다.");
+        }
 
         String subchannelId = null;
         String memberId = UUID.randomUUID().toString();
@@ -190,6 +194,9 @@ public class ChatRoomService {
 
     /* 팀 변경 */
     public ChatRoomTeamChangeResponseDto changeTeam(String id, String memberId, ChatRoomTeamChangeRequestDto chatRoomTeamChangeRequestDto) {
+        if (isRollBack) {
+            throw new IllegalArgumentException("현재 롤백 처리 중이기 때문에 변경이 불가능합니다.");
+        }
 
         ChatRoom chatRoom = chatRoomRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방을 찾을 수 없습니다."));
@@ -381,14 +388,17 @@ public class ChatRoomService {
             if (ChatRoomSubscriptionFailureDto.getType().equals(ENTER_FALIED)) {
                 validateRole(participant.getRole(), originRole, "참가자의 역할이 변경하려던 역할과 일치하지 않습니다.");
                 rollbackJoin(chatRoom, memberId, originRole);
+                isRollBack = true;
             } else if (ChatRoomSubscriptionFailureDto.getType().equals(TEAM_CHANGE_FALIED)) {   /* 팀 변경 실패시 롤백 처리 */
                 String newRole = ChatRoomSubscriptionFailureDto.getNewRole()
                         .orElseThrow(() -> new IllegalArgumentException("newRole 필드가 존재하지 않습니다."));
                 validateRole(participant.getRole(), newRole, "참가자의 역할이 변경하려던 역할과 일치하지 않습니다.");
                 rollbackTeamChange(chatRoom, memberId, originRole, newRole);
+                isRollBack = true;
             }
 
             /* 롤백 완료 메시지 반환 */
+            isRollBack = false;
             return "롤백완료";
 
         } catch (Exception e) {
@@ -657,7 +667,7 @@ public class ChatRoomService {
 //            // 서브 채널 검증
 //            validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
 //        }
-        validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
+//        validateSubChannel(chatRoom, channelId, chatRoomSendMessageRequestDto.getType());
 
         List<Participant> participants = chatRoom.getParticipants();
         if (participants == null || participants.isEmpty()) {

--- a/src/main/java/server/cubeTalk/common/config/WebSocketConfig.java
+++ b/src/main/java/server/cubeTalk/common/config/WebSocketConfig.java
@@ -7,6 +7,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 
 @Configuration
@@ -51,4 +52,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.setSendTimeLimit(20000);  // 메시지를 보내기 위한 시간 제한을 20초로 설정
+        registry.setSendBufferSizeLimit(512 * 1024);  // 512KB 버퍼 크기
+        registry.setTimeToFirstMessage(30000); // 세션 타임아웃
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,4 +20,9 @@ springdoc:
   default-produces-media-type: application/json
   writer-with-default-pretty-printer: true
   model-and-view-allowed: true
+server:
+  servlet:
+    session:
+      timeout: 30s  # 세션 타임아웃 설정 (30초)
+
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
구독 세션 유지 설정 및 채팅 메시지 검증 수정
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
-application.yml, websockeetconfig : 구독 세션 타임아웃 설정
- chatroomservice : pub/message/channelId:  channelId 메인 채팅방이 아닌 경우에만 서브채널 검증, 메인 채팅방인 경우 메세지 발행이 가능하도록 수정(모든 타입이 메세지 전송 가능)

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
