### PR TITLE
[Fix/55] 준비상태 변경 -> 이전의 참가자 객체 remove되지 않는 문제 해결

### DIFF
--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -623,8 +623,10 @@ public class ChatRoomService {
 
 
         for (SubChatRoom subChatRoom : chatRoom.getSubChatRooms()) {
-            subChatRoom.getParticipants().removeIf(participant -> participant.getMemberId().equals(p.getMemberId()));
-            break;
+            if (subChatRoom.getType().equals(p.getRole())) {
+                subChatRoom.getParticipants().removeIf(participant -> participant.getMemberId().equals(p.getMemberId()));
+                break;
+            }
         }
 
         Participant updatedParticipant = Participant.builder()


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
준비상태 변경 -> 이전의 참가자 객체 remove되지 않는 문제 해결
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
준비상태변경 
chatRoomService : removeIf 조건 추가

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
