### PR TITLE
[Fix/55] 채팅방 시작 참가자 PENDING 상태 체크하도록 수정

### DIFF
--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -737,7 +737,7 @@ public class ChatRoomService {
         if (!chatRoom.getOwnerId().equals(chatRoomStartRequestDto.getOwnerId()))
             throw new IllegalArgumentException("방장만 시작할 수 있습니다.");
 
-        boolean isPendingParticipant = chatRoom.getParticipants().stream().anyMatch(participant -> participant.getStatus().equals("READY"));
+        boolean isPendingParticipant = chatRoom.getParticipants().stream().anyMatch(participant -> participant.getStatus().equals("PENDING"));
 
         if (isPendingParticipant) {
             throw new IllegalArgumentException("참가자 모두 준비상태여야 시작할 수 있습니다.");


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
채팅방 시작하기 -> READY 상태가 있으면 시작 못하게 되어있었음
PENDING 을 확인하는 걸로  수정

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
