### PR TITLE
[Fix/55] 팀변경 메세지 추가 및 준비상태시 자유채팅방 유효성 검증 수정

### DIFF
--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -174,9 +174,10 @@ public class ChatRoomService {
         }
 
         String message = nickName + "님이 입장하셨습니다.";
-        ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto("ENTER", message);
-        messageSendingOperations.convertAndSend( "/topic/chat." + chatRoom.getChannelId(), chatMessage);
-        if (chatRoomJoinRequestDto.getRole().equals("찬반")) messageSendingOperations.convertAndSend( "/topic/chat." + subchannelId, chatMessage);
+        sendChatRoomMessage("EVENT",message,"/topic/chat." + chatRoom.getChannelId());
+        if (chatRoomJoinRequestDto.getRole().equals("찬반")) {
+            sendChatRoomMessage("EVENT",message,"/topic/chat." + subchannelId);
+        }
 
         memberRepository.save(member);
         chatRoomRepository.save(chatRoom);
@@ -322,7 +323,29 @@ public class ChatRoomService {
 
         webSocketService.sendParticiPantsList(updatedChatRoom);
 
+        // 팀 변경 메시지
+        String message = searchParticipant.getNickName() + "님이 " + chatRoomTeamChangeRequestDto.getRole() + "팀으로 팀을 변경하셨습니다.";
+        sendChatRoomMessage("EVENT", message, "/topic/chat." + chatRoom.getChannelId());
+
+        // 입장 메시지
+        String subMessage = searchParticipant.getNickName() + "님이 입장하셨습니다.";
+        if (chatRoom.getChatMode().equals("찬반")) {
+            sendChatRoomMessage("EVENT", subMessage, "/topic/chat." + Arrays.toString(changeSubChannelId));
+        }
+
+        // 퇴장 메시지
+        String subExitMessage = searchParticipant.getNickName() + "님이 퇴장하셨습니다.";
+        if (chatRoom.getChatMode().equals("찬반")) {
+            sendChatRoomMessage("EVENT", subExitMessage, "/topic/chat." + Arrays.toString(changeSubChannelId));
+        }
+
         return new ChatRoomTeamChangeResponseDto(id, chatRoom.getChannelId(), changeSubChannelId[0], chatRoomTeamChangeRequestDto.getSubChannelId());
+    }
+
+    /* 메세지 전달 */
+    public void sendChatRoomMessage(String eventType, String messageContent, String destination) {
+        ChatRoomCommonMessageResponseDto chatMessage = new ChatRoomCommonMessageResponseDto(eventType, messageContent);
+        messageSendingOperations.convertAndSend(destination, chatMessage);
     }
 
 

--- a/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
+++ b/src/main/java/server/cubeTalk/chat/service/ChatRoomService.java
@@ -618,7 +618,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방을 찾을 수 없습니다."));
         final String title = "참여자목록 불러오기";
-        if (!chatRoom.getChatMode().equals(chatRoomReadyStatusRequestDto.getType()) || !chatRoomReadyStatusRequestDto.getType().equals("찬반")) {
+        if (!chatRoom.getChatMode().equals(chatRoomReadyStatusRequestDto.getType()) && !(chatRoomReadyStatusRequestDto.getType().equals("찬반") || chatRoomReadyStatusRequestDto.getType().equals("자유"))) {
             webSocketService.sendErrorMessage(title, "채팅방 모드와 request의 type이 일치하지않습니다.");
             throw new IllegalArgumentException("채팅방 모드와 request의 type이 일치하지않습니다.");
         }

--- a/src/main/java/server/cubeTalk/chat/service/WebSocketService.java
+++ b/src/main/java/server/cubeTalk/chat/service/WebSocketService.java
@@ -304,14 +304,6 @@ public class WebSocketService {
                 ))
                 .collect(Collectors.toList());
 
-
-//        for (ChatRoomParticipantsListResponseDto participantDto : responseDto) {
-//            log.info("참여자 정보: 닉네임={}, 역할={}, 상태={}",
-//                    participantDto.getNickName(),
-//                    participantDto.getRole(),
-//                    participantDto.getStatus());
-//        }
-
         messagingTemplate.convertAndSend("/topic/"+chatRoom.getId() + ".participants.list", CommonResponseDto.success(responseDto));
 
     }


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- chatRoomService : 팀 변경 메서드 변경메세지 추가와 입, 퇴장 메세지 전달로직추가
- chatRoomService :  채팅방 준비 상태 변경시 자유채팅방 유효성 허용
- websockerService : 참가자 리스트 전달 / 불필요한 주석 제거

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### ✅ check-list
- [] 이슈 내용을 전부 적용했나요?
  
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
